### PR TITLE
Fix hive-metastore Dockerfile

### DIFF
--- a/docker/images/hive-metastore/Dockerfile
+++ b/docker/images/hive-metastore/Dockerfile
@@ -5,9 +5,13 @@ USER root
 # Copy file hive-site.xml vào image (bạn tự tạo file này ở cùng Dockerfile)
 COPY hive-site.xml /opt/hive/conf/hive-site.xml
 
-# Tải driver MySQL
-RUN wget -qO /opt/hive/lib/mysql-connector-j-8.3.0.jar \
-    https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.3.0/mysql-connector-j-8.3.0.jar
+# Cài wget (nếu ảnh gốc chưa có) và tải driver MySQL
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget -qO /opt/hive/lib/mysql-connector-j-8.3.0.jar \
+        https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.3.0/mysql-connector-j-8.3.0.jar && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 USER 1000
 ENV SERVICE_NAME=metastore


### PR DESCRIPTION
## Summary
- install wget before downloading MySQL connector
- fetch the connector driver and cleanup apt cache

## Testing
- `wget -qO /tmp/mysql-connector-j-8.3.0.jar https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.3.0/mysql-connector-j-8.3.0.jar`


------
https://chatgpt.com/codex/tasks/task_e_684bad5300788327a8c69eafcccfeed5