### PR TITLE
Fix hive metastore startup order

### DIFF
--- a/docker/compose/docker-compose.run.yml
+++ b/docker/compose/docker-compose.run.yml
@@ -50,15 +50,21 @@ services:
       - MYSQL_DATABASE=metastore
       - MYSQL_USER=hive
       - MYSQL_PASSWORD=hive123
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "hive", "-phive123"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     networks:
       - lakehouse-net
-  
+
   hive-metastore:
     image: lakehouse/hive-metastore:4.0.0
     environment:
       - SERVICE_NAME=metastore
     depends_on:
-      - metastore-db
+      metastore-db:
+        condition: service_healthy
     ports:
       - "9083:9083"
     networks:

--- a/docker/images/hive-metastore/Dockerfile
+++ b/docker/images/hive-metastore/Dockerfile
@@ -5,9 +5,13 @@ USER root
 # Copy file hive-site.xml vào image (bạn tự tạo file này ở cùng Dockerfile)
 COPY hive-site.xml /opt/hive/conf/hive-site.xml
 
-# Tải driver MySQL
-RUN wget -qO /opt/hive/lib/mysql-connector-j-8.3.0.jar \
-    https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.3.0/mysql-connector-j-8.3.0.jar
+# Cài wget (nếu ảnh gốc chưa có) và tải driver MySQL
+RUN apt-get update && \
+    apt-get install -y wget && \
+    wget -qO /opt/hive/lib/mysql-connector-j-8.3.0.jar \
+        https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.3.0/mysql-connector-j-8.3.0.jar && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 USER 1000
 ENV SERVICE_NAME=metastore


### PR DESCRIPTION
## Summary
- add healthcheck for MySQL container
- wait for metastore-db to be healthy before starting hive-metastore

## Testing
- `docker` and `docker-compose` commands failed: `command not found`


------
https://chatgpt.com/codex/tasks/task_e_684bad5300788327a8c69eafcccfeed5