### PR TITLE
Fix Trino Dockerfile apt-get error

### DIFF
--- a/docker/images/trino/Dockerfile
+++ b/docker/images/trino/Dockerfile
@@ -2,17 +2,17 @@ FROM trinodb/trino:468
 
 USER root
 
-# Cập nhật và cài thêm tool bằng apt
-RUN apt-get update \
- && apt-get install -y \
+# Cập nhật và cài tool bằng dnf (ảnh UBI sử dụng dnf thay vì apt)
+RUN dnf update -y \
+ && dnf install -y \
       curl \
       jq \
       wget \
       unzip \
       python3 \
       python3-pip \
- && pip3 install --no-cache-dir awscli \
- && rm -rf /var/lib/apt/lists/*
+ && dnf clean all \
+ && pip3 install --no-cache-dir awscli
 
 RUN mkdir -p /etc/trino/catalog
 


### PR DESCRIPTION
## Summary
- fix package installation in Trino Dockerfile

## Testing
- `docker --version` *(fails: command not found)*
- `docker compose -f docker/compose/docker-compose.build.yml build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cc3579c508327b1150abefdd3e34e