### PR TITLE
Add tools and data volumes to Airflow services

### DIFF
--- a/docker-compose.run.yml
+++ b/docker-compose.run.yml
@@ -184,6 +184,8 @@ services:
       - ./services/airflow/dags:/opt/airflow/dags
       - ./services/airflow/plugins:/opt/airflow/plugins
       - ./services/airflow/logs:/opt/airflow/logs
+      - ./tools:/opt/airflow/tools
+      - ./data:/opt/airflow/data
     ports:
       - "8082:8080"
     networks:
@@ -204,6 +206,8 @@ services:
       - ./services/airflow/dags:/opt/airflow/dags
       - ./services/airflow/plugins:/opt/airflow/plugins
       - ./services/airflow/logs:/opt/airflow/logs
+      - ./tools:/opt/airflow/tools
+      - ./data:/opt/airflow/data
     networks:
       - lakehouse-net
     command: scheduler


### PR DESCRIPTION
## Summary
- mount `./tools` and `./data` in `airflow-webserver` and `airflow-scheduler`

## Testing
- `docker compose -f docker-compose.run.yml config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bfa42c208327b08aaa5b80282c0a