### PR TITLE
Fix S3A class not found error in Spark jobs

### DIFF
--- a/services/spark/conf/spark-defaults.conf
+++ b/services/spark/conf/spark-defaults.conf
@@ -10,8 +10,11 @@ spark.hadoop.hive.metastore.uris           thrift://hive-metastore:9083
 spark.sql.catalogImplementation            hive
 spark.hadoop.hive.metastore.warehouse.dir  s3a://warehouse
 
-# Delta Lake dependency
-spark.jars.packages io.delta:delta-spark_2.12:3.2.0
+# Delta Lake & S3 dependencies
+# Add hadoop-aws and the AWS SDK so Spark can access the S3a filesystem
+spark.jars.packages io.delta:delta-spark_2.12:3.2.0,\
+    org.apache.hadoop:hadoop-aws:3.3.6,\
+    com.amazonaws:aws-java-sdk-bundle:1.12.641
 
 # Kích hoạt Delta Lake trong Spark
 spark.sql.extensions io.delta.sql.DeltaSparkSessionExtension


### PR DESCRIPTION
## Summary
- include Hadoop AWS jars so Spark can use the S3A filesystem

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d0ad8fb1c8327b186cc41f0ba29b2