### PR TITLE
Fix S3A class not found error in Spark jobs

### DIFF
--- a/services/spark/Dockerfile
+++ b/services/spark/Dockerfile
@@ -20,7 +20,11 @@ RUN wget -O /opt/bitnami/spark/jars/spark-sql-kafka-0-10_2.12-3.5.0.jar \
     wget -O /opt/bitnami/spark/jars/spark-token-provider-kafka-0-10_2.12-3.5.0.jar \
     https://repo1.maven.org/maven2/org/apache/spark/spark-token-provider-kafka-0-10_2.12/3.5.0/spark-token-provider-kafka-0-10_2.12-3.5.0.jar && \
     wget -O /opt/bitnami/spark/jars/commons-pool2-2.11.1.jar \
-    https://repo1.maven.org/maven2/org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1.jar
+    https://repo1.maven.org/maven2/org/apache/commons/commons-pool2/2.11.1/commons-pool2-2.11.1.jar && \
+    wget -O /opt/bitnami/spark/jars/hadoop-aws-3.3.6.jar \
+    https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/3.3.6/hadoop-aws-3.3.6.jar && \
+    wget -O /opt/bitnami/spark/jars/aws-java-sdk-bundle-1.12.641.jar \
+    https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.641/aws-java-sdk-bundle-1.12.641.jar
 
 # Cài thêm Python libs cho job
 RUN pip install --no-cache-dir \


### PR DESCRIPTION
## Summary
- pre-bundle Hadoop AWS libraries in Spark Dockerfile
- remove now unnecessary S3 packages from spark-defaults

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685d0ad8fb1c8327b186cc41f0ba29b2